### PR TITLE
Add Makefile for building and testing Go binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.RECIPEPREFIX := >
+BIN_DIR := bin
+
+.PHONY: all build server client test clean
+
+all: build
+
+build: server client
+
+server: | $(BIN_DIR)
+>go build -o $(BIN_DIR)/server ./cmd/server
+
+client: | $(BIN_DIR)
+>go build -o $(BIN_DIR)/client ./cmd/client
+
+$(BIN_DIR):
+>mkdir -p $(BIN_DIR)
+
+test:
+>go test ./...
+
+clean:
+>rm -rf $(BIN_DIR)


### PR DESCRIPTION
## Summary
- add Makefile with build, test, and clean targets using custom recipe prefix

## Testing
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b58f123b7c8320a65ba19e6d1948ba