### PR TITLE
feat: validate server build id

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -113,6 +113,23 @@ func runSession(id string, conn net.Conn) error {
         return fmt.Errorf("TOFU handshake fail: %w", err)
     }
 
+    // read server build id
+    b, err := sess.ReadMsg()
+    if err != nil {
+        return fmt.Errorf("read build id: %w", err)
+    }
+
+    var hello p.Message
+    if err := json.Unmarshal(b, &hello); err != nil {
+        return fmt.Errorf("decode build id: %w", err)
+    }
+    if hello.Type != "build_id" {
+        return fmt.Errorf("unexpected first message type: %s", hello.Type)
+    }
+    if hello.BuildID != BuildID {
+        return fmt.Errorf("build id mismatch: server=%s client=%s", hello.BuildID, BuildID)
+    }
+
     c := &Client{
         id:   id,
         conn: conn,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -189,6 +189,14 @@ func handleConn(h *Hub, conn net.Conn, serverPub, serverSec [32]byte) {
         }
     }()
 
+    // send build id
+    hello := &p.Message{Type: "build_id", BuildID: BuildID}
+    hb, _ := json.Marshal(hello)
+    if err := c.sess.WriteMsg(hb); err != nil {
+        log.Printf("failed to send build id: %v", err)
+        return
+    }
+
     // first frame must be register
     b, err := c.sess.ReadMsg()
     if err != nil {

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -15,8 +15,10 @@ import (
 
 type Message struct {
     ID       string `json:"id"`
-    Type     string `json:"type"` // register, file, file_ack, cmd, cmd_result, pull_file, ping, pong, info, info_result
+    Type     string `json:"type"` // register, build_id, file, file_ack, cmd, cmd_result, pull_file, ping, pong, info, info_result
     ClientID string `json:"client_id,omitempty"`
+
+    BuildID string `json:"build_id,omitempty"`
 
     // file
     FilePath string `json:"file_path,omitempty"`


### PR DESCRIPTION
## Summary
- include build ID in protocol messages
- server sends build ID to client after secure handshake
- client validates server build ID and aborts on mismatch

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b5fcf27dd88320bc78f468c36ded75