### PR TITLE
Add route to ban clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,14 @@ curl -X POST http://localhost:8080/info \
   -d '{"client_id":"<id>"}'
 ```
 
+Ban a specific client:
+
+```sh
+curl -X POST http://localhost:8080/ban-client \
+  -H 'Content-Type: application/json' \
+  -d '{"client_id":"<id>"}'
+```
+
 Request info from all clients:
 
 ```sh


### PR DESCRIPTION
## Summary
- track banned clients and expose new HTTP handler to disconnect them
- block banned client IDs during connection handshake

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b6eaff6294832089804f9340d8161c