### PR TITLE
docs: add ban client curl example

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,14 @@ curl -X POST http://localhost:8080/info \
   -d '{"client_id":"<id>"}'
 ```
 
+Ban a specific client:
+
+```sh
+curl -X POST http://localhost:8080/ban-client \
+  -H 'Content-Type: application/json' \
+  -d '{"client_id":"<id>"}'
+```
+
 Request info from all clients:
 
 ```sh


### PR DESCRIPTION
## Summary
- document HTTP API endpoint to ban a client in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b6eca2966c8320a0eda3580101a4b5